### PR TITLE
Allow for unspecified S3Variable.Use

### DIFF
--- a/TripleS.NET/S3Variable.cs
+++ b/TripleS.NET/S3Variable.cs
@@ -24,7 +24,7 @@ namespace TripleS.NET {
 		/// S3VariableFormat
 		/// </summary>
 		[XmlAttribute("format")]
-		[DefaultValue(S3VariableFormat.Literal)]
+		[DefaultValue(S3VariableFormat.Numeric)]
 		public S3VariableFormat Format { get; set; }
 
 		/// <summary>

--- a/TripleS.NET/S3Variable.cs
+++ b/TripleS.NET/S3Variable.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Xml;
 using System.Xml.Serialization;
@@ -39,8 +40,14 @@ namespace TripleS.NET {
 		/// must be of type S3Use
 		/// </summary>
 		[XmlAttribute("use")]
-		[DefaultValue(S3Use.Serial)]
-		public S3Use Use { get; set; }
+		public string UseString
+		{
+			get => Use.HasValue ? Use.Value.ToString() : null;
+			set => Use = string.IsNullOrEmpty(value) ? null : (S3Use)Enum.Parse(typeof(S3Use), value, ignoreCase: true);
+		}
+		public bool ShouldSerializeUseString() => Use.HasValue;
+		[XmlIgnore]
+		public S3Use? Use { get; set; }
 
 		/// <summary>
 		/// Mandatory. The variable_name should represent the name of the variable in 

--- a/TripleS.Tests/TripleS.Tests.csproj
+++ b/TripleS.Tests/TripleS.Tests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <EmbeddedResource Include="v20\example1.sss" />
     <EmbeddedResource Include="v20\example2.sss" />
+    <EmbeddedResource Include="v20\example3.sss" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TripleS.Tests/V2Tests.cs
+++ b/TripleS.Tests/V2Tests.cs
@@ -9,6 +9,7 @@ namespace TripleS.Tests {
 	public class V2Tests {
 		S3Root example1;
 		S3Root example2;
+		S3Root example3;
 
 		[TestInitialize()]
 		public void Initialize() {
@@ -18,6 +19,9 @@ namespace TripleS.Tests {
 
 			resource = assembly.GetManifestResourceStream("TripleS.Tests.v20.example2.sss");
 			example2 = S3Serializer.FromStream(resource);
+
+			resource = assembly.GetManifestResourceStream("TripleS.Tests.v20.example3.sss");
+			example3 = S3Serializer.FromStream(resource);
 
 			foreach (var s3Var in example2.Survey.Record.Variables) {
 				// Do something
@@ -65,8 +69,8 @@ namespace TripleS.Tests {
 
 		[TestMethod]
 		public void TestSerialVariable() {
-			var serial = example1.Survey.Record.GetSerialVariable();
-			Assert.AreEqual("1", serial.ID);
+			var serial = example3.Survey.Record.GetSerialVariable();
+			Assert.AreEqual("2", serial.ID);
 		}
 
 		[TestMethod]

--- a/TripleS.Tests/v20/example3.sss
+++ b/TripleS.Tests/v20/example3.sss
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE sss PUBLIC "-//triple-s//DTD Survey Interchange v2.0//EN"
+                     "http://www.triple-s.org/dtd/sss_v20.dtd">
+
+<!-- Triple-S version 2.0 Metadata File Example 3 (Fixed format raw data) -->
+
+<sss version="2.0" modes="interview analysis">
+<!-- introducing modes used to specialise texts at Q2 -->
+
+<date>14 April 2005</date>
+<time>16:00</time>
+<origin>SurveyProg v1.3.05</origin>
+<user>User Site</user>
+
+<survey>
+    <name>SP5201-1</name>
+    <title>Historic House Exit Survey<br/>First Wave</title>
+      
+    <record ident="V">
+      
+        <variable ident="1" type="date">
+        <!-- date variable -->
+            <name>Q1.a</name>
+            <label>Date of visit</label>
+            <position start="7" finish="14"/>
+            <values>
+                <range from="20050101" to="20051231" />
+            </values>
+        </variable>
+         
+        <variable ident="2" type="quantity" use="serial">
+        <!-- serial variable with long name -->
+            <name>RESPONDENT_ID</name>
+            <label>Respondent ID</label>
+            <position start="1" finish="6"/>
+            <values>
+                <range from="000001" to="999999" />
+            </values>
+        </variable>
+
+    </record>
+
+</survey>
+
+</sss>


### PR DESCRIPTION
Currently the "use" attribute is defaulting to `S3Use.Serial` - this causes issues if you are trying to identify the serial variable and it is not the first variable, as all variables with it unspecified will also default to Serial. As it is optional, I changed `Use` to nullable with a backing `UseString` property for XML serialization/deserialization

I also noticed `S3VariableFormat` was defaulting to `Literal` when from the docs it sounded like it should be `Numeric`:

>The format is optional and can be used to declare the format of the codes for this variable. Only variables of type single, or of type multiple with spread format data, may have a format attribute.The default format for all variables of type single or type multiple is numeric, but if specified, it must be of S3VariableFormat

I updated the `TestSerialVariable` testcase to cover the previous behaviour where it would misidentify the serial variable when it is not the first one
