### PR TITLE
Default S3VariableFormat of Numeric

### DIFF
--- a/TripleS.NET/S3Variable.cs
+++ b/TripleS.NET/S3Variable.cs
@@ -26,7 +26,7 @@ namespace TripleS.NET {
 		/// </summary>
 		[XmlAttribute("format")]
 		[DefaultValue(S3VariableFormat.Numeric)]
-		public S3VariableFormat Format { get; set; }
+		public S3VariableFormat Format { get; set; } = S3VariableFormat.Numeric;
 
 		/// <summary>
 		/// Describes the type of data the variable represents.

--- a/TripleS.Tests/V2Tests.cs
+++ b/TripleS.Tests/V2Tests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using TripleS.NET;
 
@@ -117,6 +118,20 @@ namespace TripleS.Tests {
 			string xml = S3Serializer.ToString(example1);
 
 			Assert.IsTrue(xml.Length > 0);
+		}
+
+		[TestMethod]
+		public void TestVariableFormatDefault()
+		{
+			var variableWithUnspecifiedFormat = example2.Survey.Record.Variables.Single(v => v.Name == "Q2");
+			Assert.AreEqual(S3VariableFormat.Numeric, variableWithUnspecifiedFormat.Format);
+		}
+
+		[TestMethod]
+		public void TestVariableFormatExplicit()
+		{
+			var variableWithSpecifiedFormat = example2.Survey.Record.Variables.Single(v => v.Name == "Q8");
+			Assert.AreEqual(S3VariableFormat.Literal, variableWithSpecifiedFormat.Format);
 		}
 
 		[TestMethod]


### PR DESCRIPTION
Sorry, an oversight in the previous change here: e1383c78288f2f4af5c67ab129da6a11e3e8b5a4
As `DefaultValueAttribute` isn't used to set the value when deserializing, updating this to explicitly use `Numeric` as a default